### PR TITLE
Update to 2017.3 IntelliJ and updating README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.iml
 .idea
 out/
 .gradle

--- a/README.md
+++ b/README.md
@@ -1,6 +1,63 @@
 # intellij-remote-execute
 
-Todo
+## Introduction
+
+This is a IntelliJ plugin designed to allow you to copy your code to a server and run it. 
+The logs display within IntelliJ and you can even debug the running code!
+
+## Compatibility
+
+This plugin works in both Community Edition and Ultimate Edition of IntelliJ IDEA.
+
+We support any version of IntelliJ higher than v145.0 (e.g. IntelliJ IDEA 2017.2.2 is v172.*)
+
+## Installation
+
+The current process of installation is as follows:
+
+1) Obtain the `intellij-remote-execute.jar` (version of your choosing)
+    a) You may download the tagged versions here: <link>
+    b) You can build this yourself! (instructions below)
+2) Launch a compatible version of IntelliJ IDEA
+3) Open `Preferences` 
+4) Search/navigate to `Plugins`
+5) Select `Install plugin from disk...`
+6) Locate and select the `intellij-remote-execute.jar` you obtained
+7) Make sure you hit `Apply` before you exit `Preferences`
+8) IntelliJ IDEA will probably prompt you to restart, do so at your leisure :)
+
+## Building this plugin
+
+`./gradlew build`
+
+You may have to set the execution permissions `gradlew` first:
+
+`chmod +x gradlew`
+ 
+Alternatively just run via your native `gradle`.
+
+## Configuring the plugin
+
+Once the plugin is successfully installed, you can configure it via `Preferences`.
+
+You will find it at the bottom, under `Other Settings > Remote execution`.
+
+There you can set:
+
+- hostname (the server you are targeting)
+- user (the user you will SSH into the server as)
+- Java executable (the path to Java on the server)
+
+## Invoking the remote executor
+
+Simply right click the Java class you wish to run and 
+
+## Bugs
+
+Note that there is a bug around not being able to trigger remote execution if you have a local execution config saved.
+To fix this, you have to delete the local execution config and then invoke the remote executor.
+
+## Todo List
 - Handle remote process more sensibly
    - terminating etc.
    - ability to find leaked processes?

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,9 @@
 plugins {
-    id "org.jetbrains.intellij" version "0.2.15"
+    id "org.jetbrains.intellij" version "0.2.17"
 }
 
 version = System.getenv("TRAVIS_TAG")
 
 intellij {
-    version '2017.1.3'
-}
-
-patchPluginXml {
-    untilBuild '172.*'
+    version '2017.3'
 }

--- a/src/main/java/jheister/idearemoteexecute/RemoteExecutionConfigType.java
+++ b/src/main/java/jheister/idearemoteexecute/RemoteExecutionConfigType.java
@@ -1,6 +1,5 @@
 package jheister.idearemoteexecute;
 
-import com.intellij.execution.RunManager;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.ConfigurationType;
 import com.intellij.execution.configurations.ConfigurationTypeBase;

--- a/src/main/java/jheister/idearemoteexecute/RemoteExecutionProcessHandler.java
+++ b/src/main/java/jheister/idearemoteexecute/RemoteExecutionProcessHandler.java
@@ -24,7 +24,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 public class RemoteExecutionProcessHandler extends ProcessHandler {
-    public static final String REMOTE_DIR = "idea-remote-execution";
+    private static final String REMOTE_DIR = "idea-remote-execution";
     private final RemoteExecutionConfig config;
     private final String hostName;
     private final String javaExec;
@@ -38,9 +38,9 @@ public class RemoteExecutionProcessHandler extends ProcessHandler {
 
     public RemoteExecutionProcessHandler(RemoteExecutionConfig config, String debugJvmArgs) {
         this.config = config;
-        hostName = config.getHostName();
-        javaExec = config.getJavaExec();
-        userName = config.getUserName();
+        this.hostName = config.getHostName();
+        this.javaExec = config.getJavaExec();
+        this.userName = config.getUserName();
         this.debugJvmArgs = debugJvmArgs;
     }
 

--- a/src/main/java/jheister/idearemoteexecute/RemoteExecutionProcessHandler.java
+++ b/src/main/java/jheister/idearemoteexecute/RemoteExecutionProcessHandler.java
@@ -63,7 +63,7 @@ public class RemoteExecutionProcessHandler extends ProcessHandler {
             }
 
             if (!debugJvmArgs.isEmpty()) {
-                debugTunnel = execute(new String[]{"ssh", hostName, "-L", "5005:localhost:5005"}, SYSTEM);
+                debugTunnel = execute(new String[]{"ssh", userName.map(u -> u + "@").orElse("") + hostName, "-L", "5005:localhost:5005"}, SYSTEM);
             }
 
             int r = executeCommand(javaCommand(), STDOUT);


### PR DESCRIPTION
Heya Justin,

The plugin stopped working with the latest version of IntelliJ. I'm not sure why you had `untilBuild '172.*'` in the build.gradle file?  (latest version is now `173.*`)

I've tested this with my version of IntelliJ and it works :)

Let me know what you think :)