### PR TITLE
Allow storing multiple run configurations with different host/user/java exec settings simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,9 @@ This is a IntelliJ plugin designed to allow you to copy your code to a server an
 The logs display within IntelliJ and you can even debug the running code!
 
 ## Compatibility
-
 This plugin works in both Community Edition and Ultimate Edition of IntelliJ IDEA.
 
-We support any version of IntelliJ higher than v145.0 (e.g. IntelliJ IDEA 2017.2.2 is v172.*)
-
 ## Installation
-
 The current process of installation is as follows:
 
 1) Obtain the `intellij-remote-execute.jar` (version of your choosing)
@@ -27,7 +23,6 @@ The current process of installation is as follows:
 8) IntelliJ IDEA will probably prompt you to restart, do so at your leisure :)
 
 ## Building this plugin
-
 `./gradlew build`
 
 You may have to set the execution permissions `gradlew` first:
@@ -37,7 +32,6 @@ You may have to set the execution permissions `gradlew` first:
 Alternatively just run via your native `gradle`.
 
 ## Configuring the plugin
-
 Once the plugin is successfully installed, you can configure it via `Preferences`.
 
 You will find it at the bottom, under `Other Settings > Remote execution`.
@@ -49,11 +43,9 @@ There you can set:
 - Java executable (the path to Java on the server)
 
 ## Invoking the remote executor
-
 Simply right click the Java class you wish to run and 
 
 ## Bugs
-
 Note that there is a bug around not being able to trigger remote execution if you have a local execution config saved.
 To fix this, you have to delete the local execution config and then invoke the remote executor.
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,3 +7,8 @@ version = System.getenv("TRAVIS_TAG")
 intellij {
     version '2019.1'
 }
+
+compileJava   {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}

--- a/src/main/java/jheister/idearemoteexecute/RemoteExecutionConfig.java
+++ b/src/main/java/jheister/idearemoteexecute/RemoteExecutionConfig.java
@@ -16,7 +16,6 @@ import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ProgramRunner;
 import com.intellij.execution.ui.ConsoleView;
-import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
@@ -31,12 +30,16 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 public class RemoteExecutionConfig extends ModuleBasedConfiguration implements RunProfileWithCompileBeforeLaunchOption {
     private String classToRun = "";
     private String commandArgs = "";
     private String jvmArgs;
+
+    private String remoteHost;
+    private String remoteJavaExec;
+    private String remoteUser;
+
 
     protected RemoteExecutionConfig(@NotNull Project project, @NotNull ConfigurationFactory factory, String name) {
         super(name, new RunConfigurationModule(project), factory);
@@ -93,6 +96,9 @@ public class RemoteExecutionConfig extends ModuleBasedConfiguration implements R
         classToRun = JDOMExternalizerUtil.readField(element, "classToRun", "");
         commandArgs = JDOMExternalizerUtil.readField(element, "commandArgs", "");
         jvmArgs = JDOMExternalizerUtil.readField(element, "jvmArgs", "");
+        remoteHost = JDOMExternalizerUtil.readField(element, "remoteHost", "");
+        remoteJavaExec = JDOMExternalizerUtil.readField(element, "remoteJavaExec", "");
+        remoteUser = JDOMExternalizerUtil.readField(element, "remoteUser", "");
     }
 
     @Override
@@ -102,6 +108,9 @@ public class RemoteExecutionConfig extends ModuleBasedConfiguration implements R
         JDOMExternalizerUtil.writeField(element, "classToRun", classToRun);
         JDOMExternalizerUtil.writeField(element, "commandArgs", commandArgs);
         JDOMExternalizerUtil.writeField(element, "jvmArgs", jvmArgs);
+        JDOMExternalizerUtil.writeField(element, "remoteHost", remoteHost);
+        JDOMExternalizerUtil.writeField(element, "remoteJavaExec", remoteJavaExec);
+        JDOMExternalizerUtil.writeField(element, "remoteUser", remoteUser);
     }
 
     @Override
@@ -130,18 +139,28 @@ public class RemoteExecutionConfig extends ModuleBasedConfiguration implements R
         this.jvmArgs = jvmArgs;
     }
 
-    public String getHostName() {
-        return PropertiesComponent.getInstance().getValue(RemoteExecutionSettingsDialog.HOSTNAME_PROPERTY, "");
+    public String getRemoteHost() {
+        return remoteHost;
     }
 
-    public String getJavaExec() {
-        return PropertiesComponent.getInstance().getValue(RemoteExecutionSettingsDialog.JAVA_EXEC_PROPERTY, "");
+    public String getRemoteJavaExec() {
+        return remoteJavaExec;
     }
 
-    public Optional<String> getUserName() {
-        return Optional.of(PropertiesComponent.getInstance().getValue(RemoteExecutionSettingsDialog.USER_PROPERTY, ""))
-                .map(String::trim)
-                .filter(u -> !u.isEmpty());
+    public String getRemoteUser() {
+        return remoteUser;
+    }
+
+    public void setRemoteHost(String remoteHost) {
+        this.remoteHost = remoteHost;
+    }
+
+    public void setRemoteJavaExec(String remoteJavaExec) {
+        this.remoteJavaExec = remoteJavaExec;
+    }
+
+    public void setRemoteUser(String remoteUser) {
+        this.remoteUser = remoteUser;
     }
 
 
@@ -167,10 +186,6 @@ public class RemoteExecutionConfig extends ModuleBasedConfiguration implements R
 
         public void setAdditionalJvmArgs(String args) {
             additionalJvmArgs = args;
-        }
-
-        public String hostName() {
-            return config.getHostName();
         }
     }
 }

--- a/src/main/java/jheister/idearemoteexecute/RemoteExecutionConfigEditor.java
+++ b/src/main/java/jheister/idearemoteexecute/RemoteExecutionConfigEditor.java
@@ -12,6 +12,9 @@ class RemoteExecutionConfigEditor extends SettingsEditor<RemoteExecutionConfig> 
     private JLabel module = new JLabel("");
     private JTextField commandArgs = new JTextField();
     private JTextField jvmArgs = new JTextField();
+    private JTextField remoteHost = new JTextField();
+    private JTextField remoteJavaExec = new JTextField();
+    private JTextField remoteUser = new JTextField();
 
     @Override
     protected void resetEditorFrom(@NotNull RemoteExecutionConfig o) {
@@ -23,12 +26,19 @@ class RemoteExecutionConfigEditor extends SettingsEditor<RemoteExecutionConfig> 
         }
         commandArgs.setText(o.getCommandArgs());
         jvmArgs.setText(o.getJvmArgs());
+        remoteHost.setText(o.getRemoteHost());
+        remoteJavaExec.setText(o.getRemoteJavaExec());
+        remoteUser.setText(o.getRemoteUser());
+
     }
 
     @Override
     protected void applyEditorTo(@NotNull RemoteExecutionConfig o) throws ConfigurationException {
         o.setCommandArgs(commandArgs.getText());
         o.setJvmArgs(jvmArgs.getText());
+        o.setRemoteHost(remoteHost.getText());
+        o.setRemoteJavaExec(remoteJavaExec.getText());
+        o.setRemoteUser(remoteUser.getText());
     }
 
     @NotNull
@@ -43,6 +53,12 @@ class RemoteExecutionConfigEditor extends SettingsEditor<RemoteExecutionConfig> 
         panel.add(jvmArgs);
         panel.add(new JLabel("Program arguments:"));
         panel.add(commandArgs);
+        panel.add(new JLabel("Remote host:"));
+        panel.add(remoteHost);
+        panel.add(new JLabel("Remote Java exec:"));
+        panel.add(remoteJavaExec);
+        panel.add(new JLabel("Remote user:"));
+        panel.add(remoteUser);
         return panel;
     }
 }

--- a/src/main/java/jheister/idearemoteexecute/RemoteExecutionConfigProducer.java
+++ b/src/main/java/jheister/idearemoteexecute/RemoteExecutionConfigProducer.java
@@ -9,6 +9,14 @@ import com.intellij.openapi.util.Ref;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 
+import java.util.Optional;
+
+import static jheister.idearemoteexecute.RemoteExecutionSettingsDialog.COMMAND_ARGS_PROPERTY;
+import static jheister.idearemoteexecute.RemoteExecutionSettingsDialog.HOSTNAME_PROPERTY;
+import static jheister.idearemoteexecute.RemoteExecutionSettingsDialog.JAVA_EXEC_PROPERTY;
+import static jheister.idearemoteexecute.RemoteExecutionSettingsDialog.JVM_ARGS_PROPERTY;
+import static jheister.idearemoteexecute.RemoteExecutionSettingsDialog.USER_PROPERTY;
+
 public class RemoteExecutionConfigProducer extends RunConfigurationProducer<RemoteExecutionConfig> {
     protected RemoteExecutionConfigProducer() {
         super(RemoteExecutionConfigType.getInstance());
@@ -35,9 +43,15 @@ public class RemoteExecutionConfigProducer extends RunConfigurationProducer<Remo
         remoteExecutionConfig.setModule(module);
         remoteExecutionConfig.setName("Remote: " + mainClass.getName() + ".main()");
         remoteExecutionConfig.setClassToRun(mainClass.getQualifiedName());
+        remoteExecutionConfig.setJvmArgs(propertiesComponent.getValue(JVM_ARGS_PROPERTY, ""));
+        remoteExecutionConfig.setCommandArgs(propertiesComponent.getValue(COMMAND_ARGS_PROPERTY, ""));
+        remoteExecutionConfig.setRemoteUser(getTrimmedUserName());
+        remoteExecutionConfig.setRemoteJavaExec(propertiesComponent.getValue(JAVA_EXEC_PROPERTY, ""));
+        remoteExecutionConfig.setRemoteHost(propertiesComponent.getValue(HOSTNAME_PROPERTY, ""));
 
         return true;
     }
+
 
     @Override
     public boolean isConfigurationFromContext(RemoteExecutionConfig remoteExecutionConfig, ConfigurationContext configurationContext) {
@@ -48,4 +62,10 @@ public class RemoteExecutionConfigProducer extends RunConfigurationProducer<Remo
                 && configurationContext.getModule().equals(remoteExecutionConfig.getModule())
                 && mainClass.getQualifiedName().equals(remoteExecutionConfig.getClassToRun());
     }
+
+
+    private String getTrimmedUserName() {
+        return Optional.of(propertiesComponent.getValue(USER_PROPERTY, "")).map(String::trim).orElse("");
+    }
+
 }

--- a/src/main/java/jheister/idearemoteexecute/RemoteExecutionSettingsDialog.java
+++ b/src/main/java/jheister/idearemoteexecute/RemoteExecutionSettingsDialog.java
@@ -10,15 +10,20 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import java.awt.GridLayout;
+import java.awt.*;
 import java.util.Objects;
 
 public class RemoteExecutionSettingsDialog implements Configurable  {
+    private final PropertiesComponent propertiesComponent = PropertiesComponent.getInstance();
+
+    public static final String JVM_ARGS_PROPERTY = "jheister.idearemoteexecute.jvm_args";
+    public static final String COMMAND_ARGS_PROPERTY = "jheister.idearemoteexecute.program_args";
     public static final String HOSTNAME_PROPERTY = "jheister.idearemoteexecute.hostname";
     public static final String USER_PROPERTY = "jheister.idearemoteexecute.username";
     public static final String JAVA_EXEC_PROPERTY = "jheister.idearemoteexecute.javaexec";
-    private PropertiesComponent propertiesComponent = PropertiesComponent.getInstance();
 
+    private JTextField jvmArgsField;
+    private JTextField commandArgsField;
     private JTextField hostNameField;
     private JTextField remoteUserField;
     private JTextField javaExecField;
@@ -32,33 +37,56 @@ public class RemoteExecutionSettingsDialog implements Configurable  {
     @Nullable
     @Override
     public JComponent createComponent() {
-        JPanel panel = new JPanel(new GridLayout(3, 2));
-        panel.add(new JLabel("hostname"));
+        JPanel container = new JPanel(new BorderLayout());
+
+        container.add(new JLabel("Default values that will be applied to all new Remote Execute run configurations"), BorderLayout.NORTH);
+
+        JPanel panel = new JPanel(new GridLayout(5, 2));
+        panel.add(new JLabel("JVM arguments"));
+        jvmArgsField = new JTextField();
+        panel.add(jvmArgsField);
+
+        panel.add(new JLabel("Command arguments"));
+        commandArgsField = new JTextField();
+        panel.add(commandArgsField);
+
+        panel.add(new JLabel("Remote host"));
         hostNameField = new JTextField();
         panel.add(hostNameField);
-        panel.add(new JLabel("user"));
+
+        panel.add(new JLabel("Remote user"));
         remoteUserField = new JTextField();
         panel.add(remoteUserField);
-        panel.add(new JLabel("Java executable"));
+
+        panel.add(new JLabel("Remote Java executable"));
         javaExecField = new JTextField();
         panel.add(javaExecField);
 
+        container.add(panel, BorderLayout.CENTER);
+
+        jvmArgsField.setText(propertiesComponent.getValue(JVM_ARGS_PROPERTY, ""));
+        commandArgsField.setText(propertiesComponent.getValue(COMMAND_ARGS_PROPERTY, ""));
         hostNameField.setText(propertiesComponent.getValue(HOSTNAME_PROPERTY, ""));
         remoteUserField.setText(propertiesComponent.getValue(USER_PROPERTY, ""));
         javaExecField.setText(propertiesComponent.getValue(JAVA_EXEC_PROPERTY, ""));
 
-        return panel;
+        return container;
     }
 
     @Override
     public boolean isModified() {
-        return !(Objects.equals(hostNameField.getText(), propertiesComponent.getValue(HOSTNAME_PROPERTY, ""))
+        return !(
+                Objects.equals(jvmArgsField.getText(), propertiesComponent.getValue(JVM_ARGS_PROPERTY, ""))
+                && Objects.equals(commandArgsField.getText(), propertiesComponent.getValue(COMMAND_ARGS_PROPERTY, ""))
+                && Objects.equals(hostNameField.getText(), propertiesComponent.getValue(HOSTNAME_PROPERTY, ""))
                 && Objects.equals(javaExecField.getText(), propertiesComponent.getValue(JAVA_EXEC_PROPERTY, ""))
                 && Objects.equals(remoteUserField.getText(), propertiesComponent.getValue(USER_PROPERTY, "")));
     }
 
     @Override
     public void apply() throws ConfigurationException {
+        propertiesComponent.setValue(JVM_ARGS_PROPERTY, jvmArgsField.getText());
+        propertiesComponent.setValue(COMMAND_ARGS_PROPERTY, commandArgsField.getText());
         propertiesComponent.setValue(HOSTNAME_PROPERTY, hostNameField.getText());
         propertiesComponent.setValue(USER_PROPERTY, remoteUserField.getText());
         propertiesComponent.setValue(JAVA_EXEC_PROPERTY, javaExecField.getText());

--- a/src/main/java/jheister/idearemoteexecute/RemoteExecutionSettingsDialog.java
+++ b/src/main/java/jheister/idearemoteexecute/RemoteExecutionSettingsDialog.java
@@ -6,8 +6,11 @@ import com.intellij.openapi.options.ConfigurationException;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import java.awt.GridLayout;
 import java.util.Objects;
 
 public class RemoteExecutionSettingsDialog implements Configurable  {

--- a/src/test/java/jheister/idearemoteexecute/HelloWorld.java
+++ b/src/test/java/jheister/idearemoteexecute/HelloWorld.java
@@ -1,0 +1,31 @@
+package jheister.idearemoteexecute;
+
+import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Successfully remote executed: " + HelloWorld.class.getName() + ".main()");
+        System.out.println("Hello, " + (args.length > 0 ? args[0] : "World"));
+        System.out.println("Running on host: " + getHostname());
+        System.out.println("As user: " + getUserName());
+        System.out.println("With JVM: " + javaExec());
+    }
+
+    private static String getHostname() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            return "unknown (" + e.getMessage() + ")";
+        }
+    }
+
+    private static String getUserName() {
+        return System.getProperty("user.name");
+    }
+
+    private static String javaExec() {
+        return ManagementFactory.getRuntimeMXBean().getVmName();
+    }
+}


### PR DESCRIPTION
This turns the settings dialog into a "Default run configuration options" dialog, where any new run configuration is copied from the settings, but from then on can be modified. This allows saving multiple run configurations each with their own remote host setting, which saves jumping back and forth in the settings dialog.

It also makes it possible to have defaults for JVM args and command line options, if you want them.

(It's late and I mucked up some git commands so there's some extra commits along for the ride)